### PR TITLE
Generic vector2

### DIFF
--- a/tetris/src/core/mod.rs
+++ b/tetris/src/core/mod.rs
@@ -1,2 +1,21 @@
+/// This module contains the `Vector2` struct and related functions.
+///
+/// The [Vector2](crate::core::vector2::Vector2) struct is a generic 2D vector that can be used to represent
+/// points in a 2D space. It includes methods for creating a new vector and
+/// for creating common direction vectors.
+///
+/// # Examples
+///
+/// ```
+/// let a = Vector2::new(1.0, 1.0); 
+/// let b = Vector2::new(2.0, -1.0); 
+/// let c = a + 2 * b; 
+/// assert_eq!(a.x, 1.0); 
+/// assert_eq!(a.y, 1.0); 
+/// assert_eq!(b.x, 2.0); 
+/// assert_eq!(b.y, -1.0); 
+/// assert_eq!(c.x, 5.0); 
+/// assert_eq!(c.y, -1.0); 
+///```
 #[macro_use]
 pub mod vector2;

--- a/tetris/src/gui/interface.rs
+++ b/tetris/src/gui/interface.rs
@@ -5,7 +5,6 @@ use glium::{
      Display, Program, Frame, uniform, Surface,
 };
 
-use crate::vector2;
 use crate::vec2;
 use crate::vector2::Vec2;
 
@@ -80,7 +79,7 @@ pub struct Canvas<'a> {
 
 impl<'a> Canvas<'a> {
     pub fn draw_obj(&mut self, obj: &Object) {
-        let camera: transform::Transform = self.interface.camera.get_transformation(vector2::ZERO);
+        let camera: transform::Transform = self.interface.camera.get_transformation(Vec2::ZERO);
         let uniforms = uniform! {
             matrix:  camera.0,
         };
@@ -98,7 +97,7 @@ impl<'a> Canvas<'a> {
     pub fn draw_buffer<T: Iterator<Item = Object>>(&mut self, buffer : T ){
         let vertex_buffer = buffer.flat_map(|o| o.to_vertex_buffer()).collect::<Vec<Vertex>>();
 
-        let camera: transform::Transform = self.interface.camera.get_transformation(vector2::ZERO);
+        let camera: transform::Transform = self.interface.camera.get_transformation(Vec2::ZERO);
         let uniforms = uniform! {
             matrix:  camera.0,
         };

--- a/tetris/src/gui/mod.rs
+++ b/tetris/src/gui/mod.rs
@@ -6,12 +6,31 @@ use glium::implement_vertex;
 pub use transform::*;
 use crate::{vec2, vector2::Vec2};
 
-#[derive(Debug)]
+#[derive(Debug,Copy, Clone)]
 pub struct Rect {
     pub size: Vec2,
     pub center: Vec2,
 }
 
+impl Rect {
+    pub fn left(&self) -> f32 {
+        self.center.x - self.size.x/2. 
+    }
+    pub fn right(&self) -> f32 {
+        self.center.x + self.size.x/2. 
+    }
+    pub fn bottom(&self) -> f32 {
+        self.center.y - self.size.y/2. 
+    }
+    pub fn top(&self) -> f32 {
+        self.center.y + self.size.y/2. 
+    }
+
+    pub fn complete_in(self, other: Rect ) -> bool {
+        other.left() <= self.left() && self.right() <= other.right() &&
+        other.bottom() <= self.bottom() && self.top() <= other.top()
+    }
+}
 #[derive(Copy, Clone)]
 struct Vertex {
     position: [f32; 2],

--- a/tetris/src/main.rs
+++ b/tetris/src/main.rs
@@ -1,7 +1,10 @@
-mod gui;
+#![feature(trait_alias)]
+
+pub mod gui;
+/// Module containing the engine core, vital parts such as vectors
 #[macro_use]
-mod core;
-mod logic;
+pub mod core;
+pub mod logic;
 
 extern crate glium;
 use glium::{
@@ -12,6 +15,7 @@ use std::time;
 
 pub use crate::core::vector2;
 use crate::{gui::interface, logic::GameState};
+
 fn main() {
     const TARGET_FPS: u64 = 120;
     let event_loop = event_loop::EventLoop::new();
@@ -19,6 +23,7 @@ fn main() {
     let mut game_state = GameState::new(10, 10);
     let mut last_update =   time::Instant::now();
     let mut last_key : Option<VirtualKeyCode> = None;  
+    facade.camera.world.center = vec2!(game_state.columns, game_state.rows) * (logic::SIZE /2. );
     event_loop.run(move |ev, _, control_flow| {
         let start_time = time::Instant::now();
         if let event::Event::WindowEvent { event, .. } = ev {


### PR DESCRIPTION
# Added generic parameter to field of the vectors
- Created the alias Field, to generalize the vector component (must have addition, subtraction, multiplication and division by its own type)
- Created a Vector2 type with a generic parameter T that must be a Field.
  - Created a new method that takes two values of type K that is convertible to type T, and creates a Vector2<T>
  https://github.com/GoliasVictor/re-testes/blob/3c259a7770ef6d7798c50210363576db5d70ac71/tetris/src/core/vector2.rs#L58-L63
- Created a ToVec2<T> trait where the type can be transformed into a Vector2<T>
    - Automatically implemented for Vector<K>, where type K can be convertible to type T.
   - Automatically implemented also for tuples and vectors of size two of type T
 - Defined the Vec2 like a alias of Vector2<f32>
 - Automatically implemented basic operations (sum and subtraction, mutiplication and division by scalar)
# Other small changes
- Replaced all tuples of integers in Vector2
- Replaced  u8 to i16 to simplify the code
- Fix camera position